### PR TITLE
Added support for ssh-xmss

### DIFF
--- a/management/dns_update.py
+++ b/management/dns_update.py
@@ -364,6 +364,7 @@ def build_sshfp_records():
 		"ssh-dss": 2,
 		"ecdsa-sha2-nistp256": 3,
 		"ssh-ed25519": 4,
+		"ssh-xmss": 5,
 	}
 
 	# Get our local fingerprints by running ssh-keyscan. The output looks
@@ -382,7 +383,7 @@ def build_sshfp_records():
 				except ValueError:
 					pass
 				break
-	keys = shell("check_output", ["ssh-keyscan", "-t", "rsa,dsa,ecdsa,ed25519", "-p", str(port), "localhost"])
+	keys = shell("check_output", ["ssh-keyscan", "-t", "rsa,dsa,ecdsa,ed25519,xmss", "-p", str(port), "localhost"])
 	for key in sorted(keys.split("\n")):
 		if key.strip() == "" or key[0] == "#": continue
 		try:


### PR DESCRIPTION
- Add xmss according to RFC8391 in SSHFP dns records
- Draft Recommendations: https://tools.ietf.org/html/draft-mu-curdle-ssh-xmss-00
- Done during IETF 106 Hackathon